### PR TITLE
duplicated Constants.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Attributes
 * ansi.Reset
 * ansi.DefaultBG
 * ansi.DefaultFG
-* ansi.DefaultFG
 * ansi.Black
 * ansi.Red
 * ansi.Green


### PR DESCRIPTION
`ansi.DefaultFG` appears twice in Constants section.