### PR TITLE
Reset attributes on each color set, add "dim" attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Other examples
 
 ```go
 Color(s, "red")            // red
+Color(s, "red+d")          // red dim
 Color(s, "red+b")          // red bold
 Color(s, "red+B")          // red blinking
 Color(s, "red+u")          // red underline
@@ -73,6 +74,7 @@ Foreground Attributes
 * B = Blink
 * b = bold
 * h = high intensity (bright)
+* d = dim
 * i = inverse
 * s = strikethrough
 * u = underline

--- a/ansi.go
+++ b/ansi.go
@@ -24,6 +24,7 @@ const (
 	highIntensityBG   = 100
 
 	start         = "\033["
+	normal        = "0;"
 	bold          = "1;"
 	blink         = "5;"
 	underline     = "4;"
@@ -164,6 +165,7 @@ func colorCode(style string) *bytes.Buffer {
 
 	buf.WriteString(start)
 	base := normalIntensityFG
+	buf.WriteString(normal) // reset any previous style
 	if len(fgStyle) > 0 {
 		if strings.Contains(fgStyle, "b") {
 			buf.WriteString(bold)

--- a/ansi.go
+++ b/ansi.go
@@ -26,8 +26,9 @@ const (
 	start         = "\033["
 	normal        = "0;"
 	bold          = "1;"
-	blink         = "5;"
+	dim           = "2;"
 	underline     = "4;"
+	blink         = "5;"
 	inverse       = "7;"
 	strikethrough = "9;"
 
@@ -169,6 +170,9 @@ func colorCode(style string) *bytes.Buffer {
 	if len(fgStyle) > 0 {
 		if strings.Contains(fgStyle, "b") {
 			buf.WriteString(bold)
+		}
+		if strings.Contains(fgStyle, "d") {
+			buf.WriteString(dim)
 		}
 		if strings.Contains(fgStyle, "B") {
 			buf.WriteString(blink)

--- a/ansi_test.go
+++ b/ansi_test.go
@@ -1,6 +1,7 @@
 package ansi
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -48,5 +49,17 @@ func TestDisableColors(t *testing.T) {
 	index := strings.Index(fn("foo"), "foo")
 	if index <= 0 {
 		t.Fail()
+	}
+}
+
+func TestAttributeReset(t *testing.T) {
+	boldRed := ColorCode("red+b")
+	greenUnderline := ColorCode("green+u")
+	s := fmt.Sprintf("normal %s bold red %s green underline %s", boldRed, greenUnderline, Reset)
+	// See the results on the terminal for regression tests.
+	fmt.Printf("Colored string: %s\n", s)
+	fmt.Printf("Escaped string: %q\n", s)
+	if s != "normal \x1b[0;1;31m bold red \x1b[0;4;32m green underline \x1b[0m" {
+		t.Error("Attributes are not being reset")
 	}
 }

--- a/doc.go
+++ b/doc.go
@@ -58,6 +58,7 @@ Attributes
 	B = Blink foreground
 	u = underline foreground
 	h = high intensity (bright) foreground, background
+	d = dim foreground
 	i = inverse
 
 Wikipedia ANSI escape codes [Colors](http://en.wikipedia.org/wiki/ANSI_escape_code#Colors)


### PR DESCRIPTION
This fixes an issue where some attributes (like bold or underline) cannot
be reset without explicitly writing a reset escape code.  See the added
test for an example.

You can combine high intensity and dim!  Try "black+hb" for a dark gray.